### PR TITLE
Update to react 0.14.x api

### DIFF
--- a/infinite-scroll.js
+++ b/infinite-scroll.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var ReactDOM = require('react-dom');
 var defaultInitialPage = 1;
 var defaultOffset = 250;
 
@@ -33,7 +34,7 @@ var InfiniteScrollMixin = {
   },
 
   scrollListener: function () {
-    var el = this.getDOMNode();
+    var el = ReactDOM.findDOMNode(this);
     var offset = this.props.offset || defaultOffset;
     var scrollTop = (window.pageYOffset !== undefined) ? window.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
     if (topOfElement(el) + el.offsetHeight - scrollTop - window.innerHeight < offset) {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
   "name": "react-infinite-scroll-mixin",
   "description": "An infinite scroll mixin for React",
   "author": "Brett Ausmeier <brett@ausmeier.co.za>",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "./infinite-scroll.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/bausmeier/react-infinite-scroll-mixin.git"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Updates mixin to use `ReactDOM.findDOMNode()` which is the modern way to do `this.getDOMNode()`.

Bumps version to 0.3.0 and makes sure that react and react-dom are part of the dependencies.

I tested this setup in a staging production app by pointing locally at a repo with these changes. And infinite scrolling works nicely w/o the deprecation errors.

Feel free to skip the package.json commit if you'd like to handle that differently :+1: .

Thanks for building this :). 
